### PR TITLE
Added missing cmake link to -ldl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ endif()
 include_directories(${PROJECT_BINARY_DIR})
 if(LIBAV_IS_BUNDLED)
   target_link_libraries(groove
+    ${CMAKE_DL_LIBS}
     ${LIBAV_INSTALL}/lib/libavfilter.a
     ${LIBAV_INSTALL}/lib/libavformat.a
     ${LIBAV_INSTALL}/lib/libavcodec.a


### PR DESCRIPTION
Missing link for dlsym. Added link to library for cmake.
System:
Debian 7.4
Cmake states:
## Installation Summary
- Install Directory            : /usr/local
- Build libgroove              : yes
- Build libgrooveplayer        : yes
- Build libgrooveloudness      : yes
## Bundled Dependencies
- SDL2                         : using system library
- libav                        : ready to build
- libebur128                   : using system library
## System Dependencies
- C99 Compiler                 : OK
- threads                      : OK
- SDL2                         : OK
- ebur128                      : OK
- libavformat                  : not found - will use bundled version
- libavcodec                   : not found - will use bundled version
- libavfilter                  : not found - will use bundled version
- libavutil                    : not found - will use bundled version
- yasm                         : OK
- bzip2                        : OK
- mp3lame                      : OK
- zlib                         : OK
