### PR TITLE
Add example pkg-config config file

### DIFF
--- a/example/libgroove.pc
+++ b/example/libgroove.pc
@@ -1,0 +1,10 @@
+# For more information: http://www.freedesktop.org/wiki/Software/pkg-config/
+
+libdir=
+includedir=
+
+Name: libgroove
+Description: libgroove provides decoding and encoding of audio on a playlist.
+Version:
+Libs: -L${libdir} -lgroove -lgrooveplayer -lgrooveloudness -lgroovefingerprinter
+Cflags: -I${includedir}


### PR DESCRIPTION
Any number of individuals may choose to package libgroove for their platform.
Add an example pkg-config config file to help ensure that this is done in a
consistent manner.
