### PR TITLE
Issues in playlist when adding items on top of the queue

### DIFF
--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1318,9 +1318,9 @@ struct GroovePlaylistItem *groove_playlist_insert(struct GroovePlaylist *playlis
             item->prev = next->prev;
             item->prev->next = item;
         } else {
-            playlist->head = item;			
-			p->decode_head = playlist->head;
-			pthread_cond_signal(&p->decode_head_cond);
+            playlist->head = item;
+            p->decode_head = playlist->head;
+            pthread_cond_signal(&p->decode_head_cond);
         }
         next->prev = item;
     } else if (!playlist->head) {

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1318,7 +1318,9 @@ struct GroovePlaylistItem *groove_playlist_insert(struct GroovePlaylist *playlis
             item->prev = next->prev;
             item->prev->next = item;
         } else {
-            playlist->head = item;
+            playlist->head = item;			
+			p->decode_head = playlist->head;
+			pthread_cond_signal(&p->decode_head_cond);
         }
         next->prev = item;
     } else if (!playlist->head) {


### PR DESCRIPTION
When i have a playlist with 3 items:

- Song 1 
- Song 2
- Song 3

And i add an item on top of the playlist with the `groove_playlist_insert` function.
Adding a Song 4 and as a next song picking Song 1. The playlist get's updated. But still plays Song 1 first. 

For this to work I fixed this by also updating the `decode_head`, which is the head that get's used when playing a playlist, just like you do when there is no head yet and you create it for the first time. 
